### PR TITLE
fix: correct critical typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # git-hotfix-inquiro-23-50277-1
-This project demonstrates the implimentation of a simple hotfix workflow.
+This project demonstrates the implementation of a simple hotfix workflow.


### PR DESCRIPTION
- Changed 'implimentation' to 'implementation'
- This was causing confusion for users